### PR TITLE
Release 2.3.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silintl/vulnerability-scanner-lambda",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@silintl/vulnerability-scanner-lambda",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "license": "MIT",
       "dependencies": {
         "@silintl/vulnerability-scanner": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silintl/vulnerability-scanner-lambda",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "Use AWS Lambda to regularly scan your repos for vulnerabilities",
   "main": "handler.js",
   "scripts": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -28,6 +28,7 @@ package:
 functions:
   scanOrg:
     handler: handler.scanOrg
+    maximumRetryAttempts: 0
     environment:
       RESULTS_S3_BUCKET_PREFIX: ${self:custom.bucketPrefix}
       STAGE: ${self:custom.stage}


### PR DESCRIPTION
### Fixed
- Prevent retries of full-org scan, since our most common failure is from hitting a rate-limit