### PR TITLE
Release 2.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silintl/vulnerability-scanner-lambda",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@silintl/vulnerability-scanner-lambda",
-      "version": "2.3.4",
+      "version": "2.3.5",
       "license": "MIT",
       "dependencies": {
         "@silintl/vulnerability-scanner": "^1.6.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silintl/vulnerability-scanner-lambda",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Use AWS Lambda to regularly scan your repos for vulnerabilities",
   "main": "handler.js",
   "scripts": {

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,7 +19,7 @@ provider:
       Resource: "arn:aws:s3:::${self:custom.bucketPrefix}-${self:custom.stage}/*"
   logRetentionInDays: 14
   memorySize: 256
-  timeout: 300
+  timeout: 600
 
 package:
   exclude:


### PR DESCRIPTION
### Fixed
- Raise time limit to about double our current run times

---

Apparently the root error we've been hitting occasionally is that we are right at the edge of the allowed run time, and sometimes it takes too long and is killed (and then was previously retrying, triggering rate limits).