### PR TITLE
Include the aws-sdk

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -23,10 +23,6 @@ provider:
   memorySize: 256
   timeout: 600
 
-package:
-  patterns:
-    - '!node_modules/aws-sdk/**'
-
 functions:
   scanOrg:
     handler: handler.scanOrg


### PR DESCRIPTION
### Fixed
- Stop excluding the aws-sdk
  * Now that we're on NodeJS 18.x, the version of the aws-sdk we're using isn't automatically included.