### PR TITLE
Release 2.6.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@silintl/vulnerability-scanner-lambda",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@silintl/vulnerability-scanner-lambda",
-      "version": "2.6.5",
+      "version": "2.6.6",
       "license": "MIT",
       "dependencies": {
         "@silintl/vulnerability-scanner": "^2.0.0",
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.18.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
-      "integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg=="
+      "version": "14.18.46",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.46.tgz",
+      "integrity": "sha512-n4yVT5FuY5NCcGHCosQSGvvCT74HhowymPN2OEcsHPw6U1NuxV9dvxWbrM2dnBukWjdMYzig1WfIkWdTTQJqng=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.1360.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1360.0.tgz",
-      "integrity": "sha512-wW1CviH1s6bl5+wO+KM7aSc3yy6cQPJT85Fd4rQgrn0uwfjg9fx7KJ0FRhv+eU4DabkRjcSMlKo1IGhARmT6Tw==",
+      "version": "2.1375.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1375.0.tgz",
+      "integrity": "sha512-4JusqLa0+TJ4a2rfxuiPiaEHZVxVWDzREN8rAI4zhL+u4QbqGq95yfMh9v5QtSDkdNCAReA5DSSVXPOHbS80pA==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -459,9 +459,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -728,9 +728,9 @@
       }
     },
     "@types/node": {
-      "version": "14.18.42",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.42.tgz",
-      "integrity": "sha512-xefu+RBie4xWlK8hwAzGh3npDz/4VhF6icY/shU+zv/1fNn+ZVG7T7CRwe9LId9sAYRPxI+59QBPuKL3WpyGRg=="
+      "version": "14.18.46",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.46.tgz",
+      "integrity": "sha512-n4yVT5FuY5NCcGHCosQSGvvCT74HhowymPN2OEcsHPw6U1NuxV9dvxWbrM2dnBukWjdMYzig1WfIkWdTTQJqng=="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -738,9 +738,9 @@
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
     },
     "aws-sdk": {
-      "version": "2.1360.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1360.0.tgz",
-      "integrity": "sha512-wW1CviH1s6bl5+wO+KM7aSc3yy6cQPJT85Fd4rQgrn0uwfjg9fx7KJ0FRhv+eU4DabkRjcSMlKo1IGhARmT6Tw==",
+      "version": "2.1375.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1375.0.tgz",
+      "integrity": "sha512-4JusqLa0+TJ4a2rfxuiPiaEHZVxVWDzREN8rAI4zhL+u4QbqGq95yfMh9v5QtSDkdNCAReA5DSSVXPOHbS80pA==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -975,9 +975,9 @@
       "integrity": "sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ=="
     },
     "node-fetch": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
-      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
       "requires": {
         "whatwg-url": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@silintl/vulnerability-scanner-lambda",
-  "version": "2.6.5",
+  "version": "2.6.6",
   "description": "Use AWS Lambda to regularly scan your repos for vulnerabilities",
   "main": "handler.js",
   "scripts": {


### PR DESCRIPTION
### Fixed
- Stop excluding aws-sdk (since the version of Node we're now using doesn't include the version of the aws-sdk we're using)